### PR TITLE
torch.backends.cudnn.benchmark

### DIFF
--- a/codes/train.py
+++ b/codes/train.py
@@ -95,7 +95,7 @@ def main():
         logger.info('Random seed: {}'.format(seed))
     util.set_random_seed(seed)
 
-    torch.backends.cudnn.benckmark = True
+    torch.backends.cudnn.benchmark = True
     # torch.backends.cudnn.deterministic = True
 
     #### create train and val dataloader


### PR DESCRIPTION
The correct spelling saves 10% training time on my 1080Ti.